### PR TITLE
BugFix

### DIFF
--- a/Assets/Script/Player/Giulio_Barresi/FireOnBrazier.cs
+++ b/Assets/Script/Player/Giulio_Barresi/FireOnBrazier.cs
@@ -21,11 +21,14 @@ public class FireOnBrazier : InteractableObjects
 
     public void SpawnFireOnBrazier()
     {
-        Fire.SetActive(true);
-        portalActivated = true; //elisa
-        PlayerInteraction.instance.FireInHand = false;
-        InteractiveElement.instance.DestroyElement();
-        HUD.instance.HideFireHUD();
+        if (PlayerInteraction.instance.FireInHand == true)
+        {
+            Fire.SetActive(true);
+            portalActivated = true; //elisa
+            PlayerInteraction.instance.FireInHand = false;
+            InteractiveElement.instance.DestroyElement();
+            HUD.instance.HideFireHUD();
+        }      
     }
 
     public override void SpecificInteraction()


### PR DESCRIPTION
Sistemato bug, i bracieri si accendevano anche senza avere il fuoco in mano

Aggiunta condizione if(PlayerInteraction.instance.FireInHand == true)