### PR TITLE
Risolti alcuni bug, aggiunti alcuni script nuovi

### DIFF
--- a/Assets/Particellari_Assets/Prefabs/Fire 3.prefab
+++ b/Assets/Particellari_Assets/Prefabs/Fire 3.prefab
@@ -14,6 +14,8 @@ GameObject:
   - component: {fileID: 6175714686336521672}
   - component: {fileID: 3724682171607275880}
   - component: {fileID: -453029650372447003}
+  - component: {fileID: 1334519379}
+  - component: {fileID: 7157984748550448085}
   m_Layer: 0
   m_Name: Fire 3
   m_TagString: Fire
@@ -28,7 +30,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3518185620621399233}
-  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -11.4, y: -17.7, z: 15.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -4788,6 +4790,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioClip: {fileID: 8300000, guid: 422c9c5a025888e438a86162235e42f9, type: 3}
+  repeatedMoreTimes: 1
+  condition: {fileID: 7157984748550448085}
+  elementToTake: 1
 --- !u!82 &-453029650372447003
 AudioSource:
   m_ObjectHideFlags: 0
@@ -4885,6 +4890,33 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!136 &1334519379
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3518185620621399233}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  m_Radius: 1.51
+  m_Height: 1.4200003
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0.28}
+--- !u!114 &7157984748550448085
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3518185620621399233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32694e41de203c14fa3cad0b95e88147, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  elementofCondition: 0
 --- !u!1 &3518185620809892805
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Element.unity
+++ b/Assets/Scenes/Element.unity
@@ -7798,16 +7798,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Fire 3
       objectReference: {fileID: 0}
-    - target: {fileID: 3518185620621399233, guid: 31f2e0623b71ee5478d0a7b15955e9df,
-        type: 3}
-      propertyPath: m_TagString
-      value: Fire
-      objectReference: {fileID: 0}
-    - target: {fileID: 3518185620621399233, guid: 31f2e0623b71ee5478d0a7b15955e9df,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 3518185620621399234, guid: 31f2e0623b71ee5478d0a7b15955e9df,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -17513,6 +17503,19 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &882015005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 882014999}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32694e41de203c14fa3cad0b95e88147, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  elementofCondition: 1
 --- !u!1 &901682414
 GameObject:
   m_ObjectHideFlags: 0
@@ -18918,6 +18921,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioClip: {fileID: 8300000, guid: fd84c4665dbf05c4ea0ce1afd63d20eb, type: 3}
+  repeatedMoreTimes: 0
+  condition: {fileID: 0}
   transition: {fileID: 1810687397}
   pos: {fileID: 1616776107}
 --- !u!82 &1017876994
@@ -22285,26 +22290,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1456532505}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1334519375 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3518185620621399233, guid: 31f2e0623b71ee5478d0a7b15955e9df,
-    type: 3}
-  m_PrefabInstance: {fileID: 419294994}
-  m_PrefabAsset: {fileID: 0}
---- !u!136 &1334519379
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1334519375}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  m_Radius: 1.51
-  m_Height: 1.4200003
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0.28}
 --- !u!1 &1336529878
 GameObject:
   m_ObjectHideFlags: 0
@@ -33948,6 +33933,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioClip: {fileID: 8300000, guid: fd84c4665dbf05c4ea0ce1afd63d20eb, type: 3}
+  repeatedMoreTimes: 0
+  condition: {fileID: 0}
   transition: {fileID: 1810687397}
   pos: {fileID: 797659317}
 --- !u!82 &2066207065
@@ -34781,6 +34768,11 @@ PrefabInstance:
       propertyPath: audioClip
       value: 
       objectReference: {fileID: 8300000, guid: 7b06cb2217ef2dc4f90f0ecd1843712d, type: 3}
+    - target: {fileID: 967765115185281743, guid: cebef336ae7ad3e46b30a5a6be8439a6,
+        type: 3}
+      propertyPath: condition
+      value: 
+      objectReference: {fileID: 882015005}
     - target: {fileID: 4448758256709170460, guid: cebef336ae7ad3e46b30a5a6be8439a6,
         type: 3}
       propertyPath: m_IsActive

--- a/Assets/Script/Player/Giulio_Barresi/Conditions.cs
+++ b/Assets/Script/Player/Giulio_Barresi/Conditions.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class Conditions : MonoBehaviour
+{
+    public bool CheckCondition()
+    {
+        return SpecificCondition();
+    }
+
+    protected abstract bool SpecificCondition();
+}

--- a/Assets/Script/Player/Giulio_Barresi/Conditions.cs.meta
+++ b/Assets/Script/Player/Giulio_Barresi/Conditions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae8ffeab35100d147988e101553c4056
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Player/Giulio_Barresi/ElementsCondition.cs
+++ b/Assets/Script/Player/Giulio_Barresi/ElementsCondition.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ElementsCondition : Conditions
+{
+    [SerializeField] GameManager.Elements elementofCondition;
+
+    protected override bool SpecificCondition()
+    {
+        return elementofCondition == PlayerInteraction.instance.elementInHand;
+    }
+}

--- a/Assets/Script/Player/Giulio_Barresi/ElementsCondition.cs.meta
+++ b/Assets/Script/Player/Giulio_Barresi/ElementsCondition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32694e41de203c14fa3cad0b95e88147
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Player/Giulio_Barresi/FireOnBrazier.cs
+++ b/Assets/Script/Player/Giulio_Barresi/FireOnBrazier.cs
@@ -10,7 +10,7 @@ public class FireOnBrazier : InteractableObjects
 
     public static bool portalActivated; //elisa
 
-    public GameManager.Elements myElement;
+    //public GameManager.Elements myElement;
 
     // Start is called before the first frame update
     void Start()
@@ -21,14 +21,11 @@ public class FireOnBrazier : InteractableObjects
 
     public void SpawnFireOnBrazier()
     {
-        if (PlayerInteraction.instance.FireInHand == true)
-        {
-            Fire.SetActive(true);
-            portalActivated = true; //elisa
-            PlayerInteraction.instance.FireInHand = false;
-            InteractiveElement.instance.DestroyElement();
-            HUD.instance.HideFireHUD();
-        }      
+        Fire.SetActive(true);
+        portalActivated = true; //elisa
+        //PlayerInteraction.instance.elementInHand = myElement;
+        InteractiveElement.instance.DestroyElement();
+        HUD.instance.HideFireHUD();   
     }
 
     public override void SpecificInteraction()

--- a/Assets/Script/Player/Giulio_Barresi/GameManager.cs
+++ b/Assets/Script/Player/Giulio_Barresi/GameManager.cs
@@ -31,7 +31,7 @@ public class GameManager : MonoBehaviour
 
     public enum Elements
     {
-        Fire, Water, Air, Earth
+        None, Fire, Water, Air, Earth
     }
 
     public List<InteractableObjects> interactableObjectsList = new List<InteractableObjects>();

--- a/Assets/Script/Player/Giulio_Barresi/InteractableObjects.cs
+++ b/Assets/Script/Player/Giulio_Barresi/InteractableObjects.cs
@@ -10,6 +10,12 @@ public class InteractableObjects : MonoBehaviour
     private AudioSource audioSource;
     [SerializeField] private AudioClip audioClip;
 
+    bool interacted;
+
+    [SerializeField] bool repeatedMoreTimes;
+
+    [SerializeField] Conditions condition;
+
     void Awake()
     {
         audioSource = GetComponent<AudioSource>();
@@ -30,8 +36,15 @@ public class InteractableObjects : MonoBehaviour
 
     public void Interact()
     {
-        SpecificInteraction();
-        PlayAudioClip();
+        if (condition == null || condition.CheckCondition())
+        {
+            if (interacted == false || repeatedMoreTimes == true)
+            {
+                SpecificInteraction();
+                PlayAudioClip();
+                interacted = true;
+            }
+        }  
     }
 
     public virtual void SpecificInteraction()

--- a/Assets/Script/Player/Giulio_Barresi/InteractiveElement.cs
+++ b/Assets/Script/Player/Giulio_Barresi/InteractiveElement.cs
@@ -35,6 +35,7 @@ public class InteractiveElement : MonoBehaviour
         foreach(GameObject gameObject in ElementInstantiated)
         {
             gameObject.SetActive(false);
+            PlayerInteraction.instance.elementInHand = GameManager.Elements.None;
         }
     }
 }

--- a/Assets/Script/Player/Giulio_Barresi/PlayerInteraction.cs
+++ b/Assets/Script/Player/Giulio_Barresi/PlayerInteraction.cs
@@ -5,18 +5,20 @@ using UnityEngine.UI;
 
 public class PlayerInteraction : MonoBehaviour
 {
-    [SerializeField]
+    /*[SerializeField]
     public bool FireInHand;
     [SerializeField]
     public bool WaterInHand;
     [SerializeField]
     public bool AirInHand;
     [SerializeField]
-    public bool EarthInHand;
+    public bool EarthInHand;*/
 
     public InteractableObjects interactableObjects;
 
     public static PlayerInteraction instance;
+
+    public GameManager.Elements elementInHand;
 
     //Temporary
     [SerializeField] private Image customImage;
@@ -24,10 +26,10 @@ public class PlayerInteraction : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        FireInHand = false;
+        /*FireInHand = false;
         WaterInHand = false;
         AirInHand = false;
-        EarthInHand = false;
+        EarthInHand = false;*/
 
         HUD.instance.HideFireHUD();
     }
@@ -47,11 +49,12 @@ public class PlayerInteraction : MonoBehaviour
     {
         if (Input.GetKeyDown(KeyCode.P))
         {
-            FireInHand = false;
+            //FireInHand = false;
+            elementInHand = GameManager.Elements.None;
             HUD.instance.HideFireHUD();
-            WaterInHand = false;
-            AirInHand = false;
-            EarthInHand = false;
+            //WaterInHand = false;
+            //AirInHand = false;
+            //EarthInHand = false;
             GameManager.interactiveElement.DestroyElement();
         }
     }

--- a/Assets/Script/Player/Giulio_Barresi/TakeElement.cs
+++ b/Assets/Script/Player/Giulio_Barresi/TakeElement.cs
@@ -5,11 +5,16 @@ using UnityEngine.UI;
 
 public class TakeElement : InteractableObjects
 {
+    [SerializeField] GameManager.Elements elementToTake;
+
     void Take()
     {
-        PlayerInteraction.instance.FireInHand = true;
-        HUD.instance.ShowFireHUD();
-        GameManager.interactiveElement.SpawnFire();
+        PlayerInteraction.instance.elementInHand = elementToTake;           
+        if(elementToTake == GameManager.Elements.Fire)
+        {
+            HUD.instance.ShowFireHUD();
+            GameManager.interactiveElement.SpawnFire();
+        }
     }
 
     public override void SpecificInteraction()


### PR DESCRIPTION
Creati due nuovi script

Element Condition controlla quale elemento ha bisogno un determinato GameObject per poter essere attivato dal giocatore, es. Il braciere ha bisogno del fuoco per essere attivato.

Condition controlla se l'elemento che ha in mano il giocatore e' lo stesso di quello di cui ha bisogno il GameObject, es. lo script ElementCondition assegnato al braciere controlla se il giocatore ha in mano l'elemento giusto per poter essere attivato.

Aggiornato il prefab del fuoco con il nuovo script element condition

Ogni elemento del gioco deve avere la condizione none, ovvero il player non deve avere nulla in mano per poter prendere l'elemento.

Questo fara' in modo di poter distinguere gli oggetti con cui si puo' interagire una volta sola da quelli che si possono prendere e/o usare piu' volte come ad esempio i bracieri che vanno attivati una volta sola, e gli elementi che si possono prendere piu' volte.